### PR TITLE
update Dockerfile to include -y flag for apt-get upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm-slim
 
 # Update and upgrade packages
-RUN apt-get update && apt-get upgrade
+RUN apt-get update && apt-get upgrade -y
 
 # Install JDK and any needed utilities
 RUN apt-get install -y openjdk-17-jre-headless \


### PR DESCRIPTION
This to address the #3 issue
This pull request includes a small change to the `Dockerfile`. The change ensures that the `apt-get upgrade` command runs non-interactively by adding the `-y` flag.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L4-R4): Added the `-y` flag to the `apt-get upgrade` command to ensure it runs non-interactively.